### PR TITLE
Update installation instructions

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -34,8 +34,8 @@ Make sure all requirements are installed
 To create a package and install it, do
 ::
 
-   make package
    pip3 install wheel
+   make package
    pip3 install build/dist/abcpy-0.6.3-py3-none-any.whl
 
 ``wheel`` is required to install in this way.


### PR DESCRIPTION
I tried to build the package because the pip installation fails, see issue https://github.com/eth-cscs/abcpy/issues/111. When building it with
```bash
make package
pip3 install wheel
pip3 install build/dist/abcpy-0.6.3-py3-none-any.whl
```
I received errors saying of type
```bash
>python3 setup.py -v bdist_wheel -d build/dist
command not found `bidet_wheel
```

Switching the order of the statements fixed it.
```bash
pip3 install wheel
make package
pip3 install build/dist/abcpy-0.6.3-py3-none-any.whl
```